### PR TITLE
Fix compile error ...

### DIFF
--- a/src/VCS.py
+++ b/src/VCS.py
@@ -375,7 +375,7 @@ class VcsSetupScreen(Screen, ConfigListScreen):
 			return
 		if os.path.exists(examples_sh):
 			try:
-				os.chmod(examples_sh, 0755)
+				os.chmod(examples_sh, 0o755)
 				self.session.open(Console, _("Examples:"), ["%s" % examples_sh])
 			except:
 				pass


### PR DESCRIPTION
| SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers